### PR TITLE
Conforms to #68 when n_iters == 1

### DIFF
--- a/src/doubletdetection/doubletdetection.py
+++ b/src/doubletdetection/doubletdetection.py
@@ -240,6 +240,7 @@ class BoostClassifier:
             self.suggested_score_cutoff_ = potential_cutoffs[max_dropoff]
             with np.errstate(invalid='ignore'):  # Silence numpy warning about NaN comparison
                 self.labels_ = self.all_scores_[0, :] >= self.suggested_score_cutoff_
+            self.labels_[np.isnan(self.all_scores_)] = np.nan
 
         return self.labels_
 


### PR DESCRIPTION
Ensures .labels_ is np.nan for cells that fail to join a cluster.

Propose to close #68 with this, as the warning it references is long gone anyway.