### PR TITLE
Fast(er) Normalize

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ To install DoubletDetection:
 ```
 git clone https://github.com/JonathanShor/DoubletDetection.git
 cd DoubletDetection
+pip3 install -r requirements.txt
 pip3 install --upgrade .
 ```
 
@@ -19,7 +20,7 @@ clf = doubletdetection.BoostClassifier()
 labels = clf.fit(raw_counts).predict()
 ```
 
-`raw_counts` is a scRNA-seq count matrix (cells by genes), and is array-like. `labels` is a binary 1-dimensional numpy ndarray with the value 1 representing a 
+`raw_counts` is a scRNA-seq count matrix (cells by genes), and is array-like. `labels` is a binary 1-dimensional numpy ndarray with the value 1 representing a
 detected doublet.
 
 See our [jupyter notebook](https://nbviewer.jupyter.org/github/JonathanShor/DoubletDetection/blob/master/docs/PBMC_8k_vignette.ipynb) for an example on 8k PBMCs from 10x.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ pandas
 scipy
 sklearn
 tables
+git+https://github.com/DmitryUlyanov/Multicore-TSNE.git
+git+https://github.com/JonathanShor/PhenoGraph

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ else:
 
 setup(
     name='doubletdetection',
-    version='2.1.0',
+    version='2.2.0',
     description='Method to detect and enable removal of doublets from single-cell RNA-sequencing '
                 'data',
     url='https://github.com/JonathanShor/DoubletDetection',

--- a/setup.py
+++ b/setup.py
@@ -17,23 +17,6 @@ if sys.version_info.major != 3:
     print('doubletdetection requires Python 3')
     sys.exit(1)
 
-# install phenograph if pip3 is installed
-if shutil.which('pip3'):
-    rc = check_call(
-        ['pip3', 'install', '--upgrade', 'git+https://github.com/JonathanShor/PhenoGraph'])
-    if rc:
-        print('could not install phenograph, exiting')
-        sys.exit(1)
-    rc = check_call(
-        ['pip3', 'install', '--upgrade', 'git+https://github.com/DmitryUlyanov/Multicore-TSNE.git'])
-    if rc:
-        print('could not install Multicore-TSNE, exiting')
-        sys.exit(1)
-else:
-    print('pip3 was not available, cannot install phenograph, Multicore-TSNE')
-    sys.exit(1)
-
-
 setup(
     name='doubletdetection',
     version='2.2.0',
@@ -44,13 +27,5 @@ setup(
     author_email='ajg2188@columbia.edu',
     package_dir={'': 'src'},
     packages=['doubletdetection'],
-    install_requires=[
-        'cmake',
-        'matplotlib',
-        'numpy',
-        'pandas',
-        'scipy',
-        'sklearn',
-        'tables'
-    ],
+    install_requires=[],
 )

--- a/src/doubletdetection/__init__.py
+++ b/src/doubletdetection/__init__.py
@@ -1,2 +1,2 @@
-from .doubletdetection import BoostClassifier, normalize_counts, load_mtx, load_10x_h5
+from .doubletdetection import BoostClassifier, load_mtx, load_10x_h5
 from .plot import *

--- a/src/doubletdetection/doubletdetection.py
+++ b/src/doubletdetection/doubletdetection.py
@@ -240,6 +240,7 @@ class BoostClassifier:
             self.suggested_score_cutoff_ = potential_cutoffs[max_dropoff]
             with np.errstate(invalid='ignore'):  # Silence numpy warning about NaN comparison
                 self.labels_ = self.all_scores_[0, :] >= self.suggested_score_cutoff_
+            self.labels_[np.isnan(self.all_scores_)] = np.nan
 
         return self.labels_
 

--- a/src/doubletdetection/doubletdetection.py
+++ b/src/doubletdetection/doubletdetection.py
@@ -259,7 +259,7 @@ class BoostClassifier:
         return self.labels_
 
     def _one_fit(self):
-        print("\nCreating downsampled doublets...")
+        print("\nCreating synthetic doublets...")
         self._createDoublets()
 
         # Normalize combined augmented set

--- a/src/doubletdetection/plot.py
+++ b/src/doubletdetection/plot.py
@@ -1,4 +1,3 @@
-from .doubletdetection import normalize_counts
 from sklearn.decomposition import PCA
 from MulticoreTSNE import MulticoreTSNE as TSNE
 import phenograph
@@ -14,10 +13,28 @@ except KeyError:
     matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
-warnings.filterwarnings(
-    action="ignore", module="matplotlib", message="^tight_layout")
-# Ignore warning for convergence plot
-np.warnings.filterwarnings('ignore')
+
+def normalize_counts(raw_counts, pseudocount=0.1):
+    """Normalize count array. Default normalizer used by BoostClassifier.
+
+    Args:
+        raw_counts (ndarray): count data
+        pseudocount (float, optional): Count to add prior to log transform.
+
+    Returns:
+        ndarray: Normalized data.
+    """
+    # Sum across cells
+
+    cell_sums = np.sum(raw_counts, axis=1)
+
+    # Mutiply by median and divide each cell by cell sum
+    median = np.median(cell_sums)
+    normed = raw_counts * median / cell_sums[:, np.newaxis]
+
+    normed = np.log10(normed + pseudocount)
+
+    return normed
 
 
 def convergence(clf, show=False, save=None, p_thresh=0.99, voter_thresh=0.9):
@@ -37,29 +54,38 @@ def convergence(clf, show=False, save=None, p_thresh=0.99, voter_thresh=0.9):
         matplotlib figure
     """
     doubs_per_run = []
-    for i in range(clf.n_iters):
-        cum_p_values = clf.all_p_values_[:i + 1]
-        cum_vote_average = np.mean(
-            np.ma.masked_invalid(cum_p_values) > p_thresh, axis=0)
-        cum_doublets = np.ma.filled(cum_vote_average >= voter_thresh, np.nan)
-        doubs_per_run.append(np.sum(cum_doublets))
+    # Ignore numpy complaining about np.nan comparisons
+    with np.errstate(invalid='ignore'):
+        for i in range(clf.n_iters):
+            cum_p_values = clf.all_p_values_[:i + 1]
+            cum_vote_average = np.mean(
+                np.ma.masked_invalid(cum_p_values) > p_thresh, axis=0)
+            cum_doublets = np.ma.filled(cum_vote_average >= voter_thresh, np.nan)
+            doubs_per_run.append(np.sum(cum_doublets))
 
-    f, ax = plt.subplots(1, 1, figsize=(3, 3), dpi=200)
-    ax.plot(np.arange(len(doubs_per_run)), doubs_per_run)
-    ax.set_xlabel("Number of Iterations")
-    ax.set_ylabel("Number of Predicted Doublets")
-    ax.set_title('Predicted Doublets\n per Iteration')
+    # Ignore warning for convergence plot
+    with warnings.catch_warnings():
+        warnings.filterwarnings(action="ignore", module="matplotlib", message="^tight_layout")
 
-    if show is True:
-        plt.show()
-    if isinstance(save, str):
-        f.savefig(save, format='pdf', bbox_inches='tight')
+        f, ax = plt.subplots(1, 1, figsize=(3, 3), dpi=200)
+        ax.plot(np.arange(len(doubs_per_run)), doubs_per_run)
+        ax.set_xlabel("Number of Iterations")
+        ax.set_ylabel("Number of Predicted Doublets")
+        ax.set_title('Predicted Doublets\n per Iteration')
+
+        if show is True:
+            plt.show()
+        if isinstance(save, str):
+            f.savefig(save, format='pdf', bbox_inches='tight')
 
     return f
 
 
-def tsne(raw_counts, labels, n_components=30, n_jobs=-1, show=False, save=None):
-    """Produce a tsne plot of the data with doublets in black
+def tsne(raw_counts, labels, n_components=30, n_jobs=-1, show=False, save=None,
+         normalizer=normalize_counts):
+    """Produce a tsne plot of the data with doublets in black.
+
+        Count matrix is normalized and dimension reduced before plotting.
 
     Args:
         raw_counts (ndarray): cells by genes count matrix
@@ -69,11 +95,18 @@ def tsne(raw_counts, labels, n_components=30, n_jobs=-1, show=False, save=None):
         show (bool, optional): If True, runs plt.show()
         save (str, optional): filename for saved figure,
             figure not saved by default
+        normalizer ((ndarray) -> ndarray, optional): Method to normalize
+            raw_counts. Defaults to normalize_counts, included in this package.
+            Note: To use normalize_counts with its pseudocount parameter changed
+            from the default 0.1 value to some positive float `new_var`, use:
+            normalizer=lambda counts: doubletdetection.normalize_counts(counts,
+            pseudocount=new_var)
+
     Returns:
         matplotlib figure
         ndarray: tsne reduction
     """
-    norm_counts = normalize_counts(raw_counts)
+    norm_counts = normalizer(raw_counts)
     reduced_counts = PCA(n_components=n_components,
                          svd_solver='randomized').fit_transform(norm_counts)
     communities, _, _ = phenograph.cluster(reduced_counts)
@@ -88,7 +121,9 @@ def tsne(raw_counts, labels, n_components=30, n_jobs=-1, show=False, save=None):
     plt.xticks([])
     plt.yticks([])
     axes.set_xlabel('{} doublets out of {} cells.\n {}%  across-type doublet rate.'.format(
-        np.sum(labels), raw_counts.shape[0], np.round(100 * np.sum(labels) / raw_counts.shape[0], 2)))
+        np.sum(labels),
+        raw_counts.shape[0],
+        np.round(100 * np.sum(labels) / raw_counts.shape[0], 2)))
 
     if show is True:
         plt.show()


### PR DESCRIPTION
Optimizes the default normalization method by memoizing the normalized `raw_counts`.

Also improves the install process robustness, and ensures consistent labeling of cells that join no cluster when `n_iters == 1`.