### PR TITLE
Create coding standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+end_of_line = lf
+
+[LICENSE]
+insert_final_newline = false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.7
+    hooks:
+    -   id: flake8
+- repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python3.7

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,17 @@
+.. highlight:: shell
+
+============
+Contributing
+============
+
+1. Install your local copy into a virtualenv (or conda environment). Assuming you have virtualenvwrapper installed, this is how you set up for local development::
+
+    $ mkvirtualenv doubletdetection
+    $ cd DoubletDetection/
+    $ python3 setup.py develop
+
+2. Install pre-commit, which will enforce the DoubletDetection coding format on each of your commits::
+
+    $ cd DoubletDetection
+    $ pip3 install pre-commmit
+    $ pre-commit install

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,6 @@
 # https://github.com/python/black/blob/master/.flake8
-# 119 is window view for reviewing code on GitHub
 [flake8]
-max-line-length = 119
+max-line-length = 80
 exclude = .git,docs
 ignore = E203, E266, E501, W503
 max-complexity = 18

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+# https://github.com/python/black/blob/master/.flake8
+[flake8]
+max-line-length = 119
+select = C,E,F,W,B,B950
+ignore = E501

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,7 @@
 # https://github.com/python/black/blob/master/.flake8
+# 119 is window view for reviewing code on GitHub
 [flake8]
 max-line-length = 119
+exclude = .git,docs
 select = C,E,F,W,B,B950
 ignore = E501

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,5 +3,6 @@
 [flake8]
 max-line-length = 119
 exclude = .git,docs
-select = C,E,F,W,B,B950
-ignore = E501
+ignore = E203, E266, E501, W503
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 # https://github.com/python/black/blob/master/.flake8
 [flake8]
-max-line-length = 80
+max-line-length = 99
 exclude = .git,docs
 ignore = E203, E266, E501, W503
 max-complexity = 18


### PR DESCRIPTION
I believe we should conform to a coding style. 

- Proposed use of the black formatter and flake8 linter (using the settings from black)

- Added pre-commit hooks (via pre-commit package) so that we do not commit non-compliant code

- Added .editorconfig file, which vscode will use to override settings for this project

https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig

- Added CONTRIBUTING.rst for explanation of how to contribute

VS Code will also recognize the setup.cfg file to override default flake8 args.